### PR TITLE
Added resolvers to build.sbt for geotrellis fat jar assembly

### DIFF
--- a/geotrellis-uberjar/build.sbt
+++ b/geotrellis-uberjar/build.sbt
@@ -32,7 +32,11 @@ lazy val commonSettings = Seq(
     case _ => MergeStrategy.first
   },
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
-  resolvers += "LocationTech GeoTrellis Releases" at "https://repo.locationtech.org/content/repositories/geotrellis-releases",
+  resolvers ++= Seq(
+    "LocationTech GeoTrellis Releases" at "https://repo.locationtech.org/content/repositories/geotrellis-releases",
+    "OSGeo repository" at "http://download.osgeo.org/webdav/geotools/",
+    "Geosolutions" at "http://maven.geo-solutions.it"
+  ),
   libraryDependencies ++= Seq(
     "org.locationtech.geotrellis" %% "geotrellis-accumulo" % Version.geotrellis,
     "org.locationtech.geotrellis" %% "geotrellis-cassandra" % Version.geotrellis,


### PR DESCRIPTION
Upon starting a clean room build, sbt assembly failed with resolution errors for geotools and jai.  Added resolvers to fix that.