### PR TITLE
Fix: Want To Add `hadoop` to `root`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 2
+VERSION := 3
 SPARK_VERSION := 2.1.0-bin-hadoop2.7
 BASE := $(subst -, ,$(notdir ${CURDIR}))
 ORG  := geodocker

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Docker container to provide a Jupyter notebook instance with GeoTrellis functi
 To use the image with a self-contained local master, type
 
 ```bash
-docker run -it --rm -p 8000:8000 quay.io/geodocker/jupyter:2
+docker run -it --rm -p 8000:8000 quay.io/geodocker/jupyter:3
 ```
 
 After a few moments, the server should be available at [`localhost:8000`](http://localhost:8000).

--- a/scripts/install-jupyter.sh
+++ b/scripts/install-jupyter.sh
@@ -10,5 +10,5 @@ ln -s $SPARK_HOME /usr/local/spark
 
 # Add User
 useradd hadoop -m
-usermod -a -G hadoop root
+usermod -a -G root hadoop
 echo 'hadoop:hadoop' | chpasswd


### PR DESCRIPTION
Previously, the user `root` was being added to the group `hadoop`.